### PR TITLE
Bugfix OpenMP build and new build target linux.intel

### DIFF
--- a/macros.make.linux.intel
+++ b/macros.make.linux.intel
@@ -1,0 +1,63 @@
+# Settings for LIBRARY BUILD ONLY: linux.intel
+#
+# Flags common to all
+RM         = rm -f
+AR         = ar
+ARFLAGS    =
+FC         = mpiifort
+FCserial   = ifort
+CC         = icc
+
+ifeq ($(OPENMP),1)
+  OMPFLAGS= -qopenmp
+else
+  OMPFLAGS=
+endif
+
+# Number of parallel tasks for gmake
+GMAKEMINUSJ = -j24
+
+# Flags for bacio library
+BACIO_FFLAGS  = $(OMPFLAGS) -O3 -xHOST -traceback -fPIC
+BACIO_CFLAGS  = $(OMPFLAGS) -O3 -DUNDERSCORE -DLINUX -fPIC
+
+# Flags for gfsio library
+GFSIO_FFLAGS  = $(OMPFLAGS) -traceback -g -xHOST -convert big_endian -assume byterecl  -I$(INCMOD) -FR -fPIC
+GFSIO_ARFLAGS = -rv
+
+# Flags for ip library
+IP_FFLAGS     = $(OMPFLAGS) -r8 -O3 -fp-model strict -ip -I. -convert little_endian -assume byterecl
+IP_FPPFLAGS   = -fpp -DLSIZE=d -save-temps
+IP_ARFLAGS    = -ruv
+
+# Flags for landsfcutil library
+LAND_FFLAGS   = $(OMPFLAGS) -r8 -O3 -fp-model strict -ip -FR -I. -module . -c
+LAND_ARFLAGS  = crvs
+
+# Flags for nemsio library
+NEMSIO_FFLAGS  = $(OMPFLAGS) -O -g -fPIC
+NEMSIO_ARFLAGS = -rvu
+
+# Flags for nemsiogfs library
+NEMSIOGFS_FFLAGS  = $(OMPFLAGS) -O3 -FR        
+
+# Flags for sfcio library
+SFCIO_FFLAGS = -O3 -traceback -axCore-AVX2 -convert big_endian -assume byterecl -I$(INCMOD) -FR
+SFCIO_ARFLAGS = -ruv
+
+# Flags for sigio library
+SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -xHOST -traceback -free -convert big_endian -assume byterecl -c -fPIC
+SIGIO_ARFLAGS = crvs
+
+# Flags for sp library
+SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC
+SP_ARFLAGS = -ruv
+
+# Flags for w3emc library
+W3EMC_FFLAGS = $(OMPFLAGS) -O2 -g -traceback -fixed -c -fPIC
+W3EMC_ARFLAGS = ruv
+
+# Flags for w3nco library
+W3NCO_FFLAGS  = $(OMPFLAGS) -O0 -g -r8 -fixed -fPIC
+W3NCO_CFLAGS  = $(OMPFLAGS) -O0 -DLINUX
+W3NCO_ARFLAGS = -ruv

--- a/make_ncep_libs.sh
+++ b/make_ncep_libs.sh
@@ -124,6 +124,7 @@ cp -v ${MACROS_FILE}.${SYSTEM}.${COMPILER} ${MACROS_FILE}
 #--------------------------------------------------------------
 # Copy library source to BUILD_DIR and build
 #--------------------------------------------------------------
+export OPENMP=${OPENMP}
 rsync -a macros.make Makefile src ${BUILD_DIR}
 cd ${BUILD_DIR}
 if [ "$COMPILEALL" == "1" ]; then
@@ -131,6 +132,7 @@ if [ "$COMPILEALL" == "1" ]; then
 else
    make some || fail "An error occurred building the NCEP libraries"
 fi
+export -n OPENMP
 
 #--------------------------------------------------------------
 # Install to NCEPLIBS_DST_DIR


### PR DESCRIPTION
Changes included:

(1) make_ncep_libs.sh: bugfix, need to export OPENMP before build command to enable OpenMP support in build

(2) new build target macros.make.linux.intel