### PR TITLE
Build option for systems without MPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,15 @@
 include ./macros.make
 
 # DH* move nemsio to end of all list
-some:
+nompi:
 	$(MAKE) $(GMAKEMINUSJ) -C src/bacio/v2.0.1/src
 	$(MAKE) $(GMAKEMINUSJ) -C src/ip/v3.0.0/sorc
 	$(MAKE) $(MAKEMINUSJ) -C src/sp/v2.0.2/src
 	$(MAKE) $(MAKEMINUSJ) -C src/sigio/v2.0.1/src
 	$(MAKE) $(MAKEMINUSJ) -C src/w3emc/v2.2.0/src # Depends on sigio 2.0.1
 	$(MAKE) $(MAKEMINUSJ) -C src/w3nco/v2.0.6/src
+
+some: nompi
 	$(MAKE) $(MAKEMINUSJ) -C src/nemsio/v2.2.3/src
 
 all: some

--- a/macros.make.linux.gnu
+++ b/macros.make.linux.gnu
@@ -6,7 +6,7 @@ AR         = ar
 ARFLAGS    =
 FC         = mpif90
 FCserial   = gfortran
-CC         = mpicc
+CC         = gcc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -fopenmp

--- a/macros.make.macosx.gnu
+++ b/macros.make.macosx.gnu
@@ -6,7 +6,7 @@ AR         = ar
 ARFLAGS    =
 FC         = mpif90
 FCserial   = gfortran
-CC         = mpicc
+CC         = clang
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -fopenmp


### PR DESCRIPTION
Provide option to compile without MPI compilers (skip nemsio), use serial C compiler on linux/macos by default. Tested on macOS (clang/gfortran) with MPI compilers and on CentOS (gcc/gfortran) without MPI compilers.