### PR TITLE
Bug fix for building libsp without openmp

### DIFF
--- a/macros.make.cheyenne.gnu
+++ b/macros.make.cheyenne.gnu
@@ -10,8 +10,10 @@ CC         = gcc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -fopenmp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -fbacktrace -ffree-form -fconvert=big-endian 
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -O3 -fdefault-real-8 -fconvert=big-endian -cpp -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -O3 -fdefault-real-8 -fconvert=big-endian -cpp -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.cheyenne.intel
+++ b/macros.make.cheyenne.intel
@@ -10,8 +10,10 @@ CC         = icc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -qopenmp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -xHOST -traceback -free -convert big_endian -
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.cheyenne.pgi
+++ b/macros.make.cheyenne.pgi
@@ -10,8 +10,10 @@ CC         = pgcc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -mp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -traceback -Mfree -byteswapio  -c -fPIC
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -traceback -O3 -Mrecursive -i4 -r8 -byteswapio -Kieee -Mpreprocess -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -traceback -O3 -Mrecursive -i4 -r8 -byteswapio -Kieee -Mpreprocess -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.gaea.intel
+++ b/macros.make.gaea.intel
@@ -10,8 +10,10 @@ CC         = icc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -qopenmp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -xHOST -traceback -free -convert big_endian -
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.hera.intel
+++ b/macros.make.hera.intel
@@ -10,8 +10,10 @@ CC         = icc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -qopenmp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -xHOST -traceback -free -convert big_endian -
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.jet.intel
+++ b/macros.make.jet.intel
@@ -10,8 +10,10 @@ CC         = icc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -qopenmp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -xHOST -traceback -free -convert big_endian -
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.linux.gnu
+++ b/macros.make.linux.gnu
@@ -10,8 +10,10 @@ ARFLAGS    =
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -fopenmp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -42,7 +44,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -fbacktrace -ffree-form -fconvert=big-endian 
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -O3 -fdefault-real-8 -fconvert=big-endian -cpp -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -O3 -fdefault-real-8 -fconvert=big-endian -cpp -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.linux.intel
+++ b/macros.make.linux.intel
@@ -10,8 +10,10 @@ CC         = icc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -qopenmp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -xHOST -traceback -free -convert big_endian -
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.macosx.gnu
+++ b/macros.make.macosx.gnu
@@ -10,8 +10,10 @@ ARFLAGS    =
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -fopenmp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -fbacktrace -ffree-form -fconvert=big-endian 
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -O3 -fdefault-real-8 -fconvert=big-endian -cpp -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -O3 -fdefault-real-8 -fconvert=big-endian -cpp -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.theia.gnu
+++ b/macros.make.theia.gnu
@@ -10,8 +10,10 @@ CC         = gcc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -fopenmp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -fbacktrace -ffree-form -fconvert=big-endian 
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -O3 -fdefault-real-8 -fconvert=big-endian -cpp -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -O3 -fdefault-real-8 -fconvert=big-endian -cpp -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.theia.intel
+++ b/macros.make.theia.intel
@@ -10,8 +10,10 @@ CC         = icc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -qopenmp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -xHOST -traceback -free -convert big_endian -
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -O3 -auto -i4 -r8 -convert big_endian -assume byterecl -fp-model strict -fpp -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/macros.make.theia.pgi
+++ b/macros.make.theia.pgi
@@ -10,8 +10,10 @@ CC         = pgcc
 
 ifeq ($(OPENMP),1)
   OMPFLAGS= -mp
+  OMPCPPFLAGS= -DOPENMP
 else
   OMPFLAGS=
+  OMPCPPFLAGS=
 endif
 
 # Number of parallel tasks for gmake
@@ -50,7 +52,7 @@ SIGIO_FFLAGS  = $(OMPFLAGS) -O0 -g -traceback -Mfree -byteswapio  -c -fPIC
 SIGIO_ARFLAGS = crvs
 
 # Flags for sp library
-SP_FFLAGS  = $(OMPFLAGS) -traceback -O3 -Mrecursive -i4 -r8 -byteswapio -Kieee -Mpreprocess -DLINUX -fPIC
+SP_FFLAGS  = $(OMPFLAGS) -traceback -O3 -Mrecursive -i4 -r8 -byteswapio -Kieee -Mpreprocess -DLINUX -fPIC $(OMPCPPFLAGS)
 SP_ARFLAGS = -ruv
 
 # Flags for w3emc library

--- a/make_ncep_libs.sh
+++ b/make_ncep_libs.sh
@@ -182,7 +182,9 @@ cp -v ${MACROS_FILE}.${SYSTEM}.${COMPILER} ${MACROS_FILE}
 #--------------------------------------------------------------
 # Copy library source to BUILD_DIR and build
 #--------------------------------------------------------------
-export OPENMP=${OPENMP}
+if [ "$OPENMP" == "1" ]; then
+  export OPENMP=${OPENMP}
+fi
 rsync -a macros.make Makefile src ${BUILD_DIR}
 cd ${BUILD_DIR}
 if [ "$APP" == "all" ]; then

--- a/src/sp/v2.0.2/src/ncpus.F
+++ b/src/sp/v2.0.2/src/ncpus.F
@@ -29,6 +29,7 @@ C$$$
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       INTEGER NTHREADS, TID, OMP_GET_NUM_THREADS,OMP_GET_THREAD_NUM
 C     Obtain thread number
+#if OPENMP == 1
 #ifdef LINUX
 !$OMP PARALLEL PRIVATE(TID)
       TID = OMP_GET_THREAD_NUM()
@@ -41,6 +42,8 @@ C     Obtain thread number
 #else
       NCPUS=NUM_PARTHDS()
 #endif
-
+#else
+      NCPUS=1
+#endif
       RETURN
       END

--- a/src/sp/v2.0.2/src/ncpus.F
+++ b/src/sp/v2.0.2/src/ncpus.F
@@ -29,7 +29,7 @@ C$$$
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       INTEGER NTHREADS, TID, OMP_GET_NUM_THREADS,OMP_GET_THREAD_NUM
 C     Obtain thread number
-#if OPENMP == 1
+#ifdef OPENMP
 #ifdef LINUX
 !$OMP PARALLEL PRIVATE(TID)
       TID = OMP_GET_THREAD_NUM()


### PR DESCRIPTION
When you do not build with openmp flags (at least for gnu, haven't tested other compilers), 'OMP_GET_THREAD_NUM' and 'OMP_GET_NUM_THREADS' can not be called because these are openmp function calls, and if we are not building with openmp flags these may not be callable.

An example of the warning messages you can get:

````
/usr/bin/ld: /glade/work/kavulich/UPP/new_build_system/NCEPlibs_gnu_8.3.0_dmpar//lib/libsp.a(ncpus.o): in function `ncpus_':
ncpus.F:(.text+0x7): undefined reference to `omp_get_thread_num_'
/usr/bin/ld: ncpus.F:(.text+0x25): undefined reference to `omp_get_num_threads_'
````

This commit includes a flag and a CPP instruction so that when building without openmp, these functions do not get called, and the calling routine which expects the number of threads always gets 1 as an answer.